### PR TITLE
Code format cleaning

### DIFF
--- a/js/superfish.js
+++ b/js/superfish.js
@@ -221,13 +221,13 @@
 
 	if (sf.ios) {
 		// iOS click won't bubble to body, attach to closest possible
-		$(window).load(function() { 
-			$('body').children().on('click', $.noop); 
+		$(window).load(function() {
+			$('body').children().on('click', $.noop);
 		});
 		$(window).on('pageshow', function(e) {
 			// only way to reset subs after back button click. Seriously.
 			if (e.originalEvent.persisted) {
-				window.location.reload(); 
+				window.location.reload();
 			}
 		});
 	}


### PR DESCRIPTION
The code formatting was suffering an identity crises, so I picked a common format for jQuery and used that (tabs, spacing, {} etc) ... 

Signed-off-by:Spuds Spuds@192.168.1.125
