### PR TITLE
Let default touch device functionality be extended/disabled via a callback

### DIFF
--- a/src/js/superfish.js
+++ b/src/js/superfish.js
@@ -78,7 +78,12 @@
 			},
 			touchHandler = function (e) {
 				var $this = $(this),
+					o = getOptions($this),
 					$ul = $this.siblings(e.data.popUpSelector);
+
+				if (o.onHandleTouch.call($ul) === false) {
+					return this;
+				}
 
 				if ($ul.length > 0 && $ul.is(':hidden')) {
 					$this.one('click.superfish', false);
@@ -245,7 +250,8 @@
 		onBeforeHide: $.noop,
 		onHide: $.noop,
 		onIdle: $.noop,
-		onDestroy: $.noop
+		onDestroy: $.noop,
+		onHandleTouch: $.noop
 	};
 
 	// soon to be deprecated


### PR DESCRIPTION
We are extending Superfish to function similar to FlexNav and the built-in touch device functionality is getting in the way.