### PR TITLE
stop $ULs from leaking into the global scope

### DIFF
--- a/src/js/supersubs.js
+++ b/src/js/supersubs.js
@@ -25,7 +25,7 @@
 			// support metadata
 			var o = $.meta ? $.extend({}, opts, $$.data()) : opts;
 			// cache all ul elements and show them in preparation for measurements
-			$ULs = $$.find('ul').show();
+			var $ULs = $$.find('ul').show();
 			// get the font size of menu.
 			// .css('fontSize') returns various results cross-browser, so measure an em dash instead
 			var fontsize = $('<li id="menu-fontsize">&#8212;</li>').css({


### PR DESCRIPTION
I noticed `$ULs` was in the global scope of a site I'm using Superfish on. I couldn't find a reason why it needed to be a global var and the tests pass after this patch.
