### PR TITLE
Allows a span to be used for menu label instead of an anchor

### DIFF
--- a/src/css/superfish.css
+++ b/src/css/superfish.css
@@ -22,7 +22,7 @@
 	display: block;
 }
 
-.sf-menu a {
+.sf-menu a, .sf-menu span {
 	display: block;
 	position: relative;
 }
@@ -42,7 +42,7 @@
 	min-width: 12em; /* allow long menu items to determine submenu width */
 	*width: 12em; /* no auto sub width for IE7, see white-space comment below */
 }
-.sf-menu a {
+.sf-menu a, .sf-menu span {
 	border-left: 1px solid #fff;
 	border-top: 1px solid #dFeEFF; /* fallback colour must use full shorthand */
 	border-top: 1px solid rgba(255,255,255,.5);
@@ -50,8 +50,11 @@
 	text-decoration: none;
 	zoom: 1; /* IE7 */
 }
-.sf-menu a {
+.sf-menu a, .sf-menu span {
 	color: #13a;
+}
+.sf-menu span {
+	cursor: default;
 }
 .sf-menu li {
 	background: #BDD2FF;

--- a/src/js/superfish.js
+++ b/src/js/superfish.js
@@ -50,7 +50,7 @@
 						}).removeClass(o.pathClass);
 			},
 			toggleAnchorClass = function ($li) {
-				$li.children('a').toggleClass(c.anchorClass);
+				$li.children('a, span').toggleClass(c.anchorClass);
 			},
 			toggleTouchAction = function ($menu) {
 				var msTouchAction = $menu.css('ms-touch-action');


### PR DESCRIPTION
I will often have 'folder' menu elements that contain sub-elements, but are not themselves a link. Using a span for the label avoids the messiness of an anchor with an empty or "#" href.