### PR TITLE
Added license to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
   	"dist/js/hoverIntent.js",
   	"dist/css/superfish.css"
   ],
+  "license": "MIT",
   "ignore": [
     "**/.*",
     "*.json",


### PR DESCRIPTION
This adds the "license" property to the bower descriptor. A valid license property is required to build a [webjar](http://www.webjars.org/) for it.