### PR TITLE
 Fix undefined styles

### DIFF
--- a/src/js/superfish.js
+++ b/src/js/superfish.js
@@ -205,7 +205,9 @@
 					$this.off('.superfish').off('.hoverIntent');
 					// clear animation's inline display style
 					$hasPopUp.children(o.popUpSelector).attr('style', function (i, style) {
-						return style.replace(/display[^;]+;?/g, '');
+						if (typeof style !== 'undefined') {
+							return style.replace(/display[^;]+;?/g, '');
+						}
 					});
 					// reset 'current' path classes
 					o.$path.removeClass(o.hoverClass + ' ' + c.bcClass).addClass(o.pathClass);


### PR DESCRIPTION
Sometimes the `style` attribute may be undefined for sub-menu items, causing the interruption of the script.

I think this is an edge case I found within a custom implementation, where I move some menu items from one menu to another. However, maybe it would be would to check for an undefined value before returning it.